### PR TITLE
Add try/finally blocks to ensure teardown always completes after bind()

### DIFF
--- a/source/context.ts
+++ b/source/context.ts
@@ -119,22 +119,28 @@ export class Context {
 
     teardown(): void {
 
-        if (this.autoFlush) {
-            this.scheduler.flush();
+        try {
+
+            if (this.autoFlush) {
+                this.scheduler.flush();
+            }
+
+        } finally {
+
+            this.bindings_.forEach(({ instance, now, schedule }) => {
+                if (now) {
+                    instance.now = now;
+                } else {
+                    delete instance.now;
+                }
+                if (schedule) {
+                    instance.schedule = schedule;
+                } else {
+                    delete instance.schedule;
+                }
+            });
         }
 
-        this.bindings_.forEach(({ instance, now, schedule }) => {
-            if (now) {
-                instance.now = now;
-            } else {
-                delete instance.now;
-            }
-            if (schedule) {
-                instance.schedule = schedule;
-            } else {
-                delete instance.schedule;
-            }
-        });
     }
 
     time(marbles: string): number {

--- a/source/marbles.ts
+++ b/source/marbles.ts
@@ -24,9 +24,13 @@ export function marbles(func: (context: Context, ...rest: any[]) => any): (...re
                 get("frameworkMatcher")
             ));
             const context = new Context(scheduler);
-            const result = func(context, first, ...rest);
-            context.teardown();
-            return result;
+
+            try {
+                const result = func(context, first, ...rest);
+                return result;
+            } finally {
+                context.teardown();
+            }
         };
     }
     return (...rest: any[]) => {
@@ -37,8 +41,12 @@ export function marbles(func: (context: Context, ...rest: any[]) => any): (...re
             get("frameworkMatcher")
         ));
         const context = new Context(scheduler);
-        const result = func(context, ...rest);
-        context.teardown();
-        return result;
+
+        try {
+            const result = func(context, ...rest);
+            return result;
+        } finally {
+            context.teardown();
+        }
     };
 }


### PR DESCRIPTION
I was experiencing cascading failures with mocha after a test that used `m.bind()` failed. Determined this to be due to `Context#teardown()` not fully completing after an error is thrown, so later tests have messed up schedulers.

This could use some regression tests, but it looks like it'd require a bit of creativity to fit them into the current e2e style tests :) I can dig in when I have time if you'd like tests before merging this.