### PR TITLE
jasmine: preserve 'this' test context

### DIFF
--- a/fixtures/jasmine/passing-spec.ts
+++ b/fixtures/jasmine/passing-spec.ts
@@ -7,7 +7,19 @@
 import { map } from "rxjs/operators";
 import { cases, marbles } from "../../dist/jasmine";
 
+interface TestContext {
+    myVariable: number;
+}
+
 describe("rxjs-marbles", () => {
+
+    beforeEach(function(this: TestContext): void {
+        this.myVariable = 57;
+    });
+
+    it("should preserve test context", marbles(function(this: TestContext, m: any): void {
+        expect(this.myVariable).toBe(57);
+    }));
 
     it("should support marble tests", marbles((m) => {
 

--- a/source/marbles.ts
+++ b/source/marbles.ts
@@ -32,7 +32,7 @@ export function marbles(func: (context: Context, ...rest: any[]) => any): (...re
             }
         };
     }
-    return (...rest: any[]) => {
+    return function(this: any, ...rest: any[]): any {
 
         const scheduler = new TestScheduler((a, b) => observableMatcher(a, b,
             get("assert"),
@@ -42,7 +42,7 @@ export function marbles(func: (context: Context, ...rest: any[]) => any): (...re
         const context = new Context(scheduler);
 
         try {
-            return func(context, ...rest);
+            return func.call(this, context, ...rest);
         } finally {
             context.teardown();
         }


### PR DESCRIPTION
This PR allows the "this" context provided by jasmine to be preserved within `marbles()` wrapped test functions.