### PR TITLE
Add test to ensure white spaces in marble diagrams are treated as non-significant 

### DIFF
--- a/fixtures/jest/passing-spec.ts
+++ b/fixtures/jest/passing-spec.ts
@@ -7,6 +7,24 @@
 import { map } from "rxjs/operators";
 import { cases, marbles } from "../../dist/jest";
 
+
+test('It should handle white space in marble diagrams correctly', marbles((m) => {
+
+    const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4
+    };
+
+    const source = m.cold('--a-b-c-|', values)
+    const expected = m.cold("--b-c-d-|", values);
+
+    const destination = source.pipe(map((value) => value + 1));
+
+    m.expect(destination).toBeObservable(expected);
+}))
+
 test("it should support marble tests", marbles((m) => {
 
     const values = {

--- a/fixtures/jest/passing-spec.ts
+++ b/fixtures/jest/passing-spec.ts
@@ -17,7 +17,7 @@ test('It should handle white space in marble diagrams correctly', marbles((m) =>
         d: 4
     };
 
-    const source = m.cold('--a-b-c-|', values)
+    const source = m.cold('  --a-b-c-|', values)
     const expected = m.cold("--b-c-d-|", values);
 
     const destination = source.pipe(map((value) => value + 1));


### PR DESCRIPTION
This test is added so that this library’s treatment of white spaces in marbles diagrams conforms to [`rxjs`'s documentation on marble syntax](https://github.com/ReactiveX/rxjs/blob/master/doc/marble-testing.md#marble-syntax) 

> `'  '` whitespace: horizontal whitespace is ignored, and can be used to help vertically align multiple marble diagrams.