### PR TITLE
fix(jest): Specify 'testURL' in Jest config

### DIFF
--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -28,7 +28,8 @@
     "testRegex": "(/__tests__/.*|-(test|spec))\\.(jsx?|tsx?)$",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
-    }
+    },
+    "testURL": "http://localhost"
   },
   "name": "rxjs-marbles-examples-jest",
   "scripts": {


### PR DESCRIPTION
This fixes the 'SecurityError: localStorage is not available for opaque origins' error when using jsdom