### PR TITLE
Fix RxJS scheduler is corrupted after fakeSchedulers usage

### DIFF
--- a/fixtures/jasmine-angular/passing-spec.ts
+++ b/fixtures/jasmine-angular/passing-spec.ts
@@ -56,4 +56,14 @@ describe("fakeSchedulers", () => {
       expect(received).toBe(1);
     })
   );
+
+  it("should not corrupt rxjs scheduler", () => {
+    fakeSchedulers(() => {})();
+
+    expect(() =>
+      of(undefined)
+        .pipe(delay(100))
+        .subscribe()
+    ).not.toThrowError();
+  });
 });

--- a/source/jasmine/angular.ts
+++ b/source/jasmine/angular.ts
@@ -4,14 +4,13 @@
  */
 
 import { fakeAsync, tick } from "@angular/core/testing";
-import { asyncScheduler } from "rxjs";
+import { fakeSchedulers as _fakeSchedulers } from "../fake";
 
 export function fakeSchedulers(
   fakeTest: (tick: (milliseconds: number) => void) => any
 ): () => any {
-  return fakeAsync(() => {
-    try {
-      asyncScheduler.now = () => Date.now();
+  return fakeAsync(
+    _fakeSchedulers(() => {
       return fakeTest(milliseconds => {
         /*tslint:disable-next-line:no-console*/
         console.log(
@@ -19,8 +18,6 @@ export function fakeSchedulers(
         );
         tick(milliseconds);
       });
-    } finally {
-      delete asyncScheduler.now;
-    }
-  });
+    })
+  );
 }

--- a/source/jest/fake.ts
+++ b/source/jest/fake.ts
@@ -3,27 +3,21 @@
  * can be found in the LICENSE file at https://github.com/cartant/rxjs-marbles
  */
 
-import { asapScheduler, asyncScheduler } from "rxjs";
+import { fakeSchedulers as _fakeSchedulers } from "../fake";
 
 declare const jest: any;
 
 export function fakeSchedulers(
   fakeTest: (advance: (milliseconds: number) => void) => any
 ): () => any {
-  return () => {
-    try {
-      let fakeTime = 0;
-      asapScheduler.schedule = asyncScheduler.schedule.bind(
-        asyncScheduler
-      ) as any;
-      asyncScheduler.now = () => fakeTime;
+  let fakeTime = 0;
+  return _fakeSchedulers(
+    () => {
       return fakeTest(milliseconds => {
         fakeTime += milliseconds;
         jest.advanceTimersByTime(milliseconds);
       });
-    } finally {
-      delete asapScheduler.schedule;
-      delete asyncScheduler.now;
-    }
-  };
+    },
+    () => fakeTime
+  );
 }


### PR DESCRIPTION
We faced an issue that usage of `fakeSchedulers` in our angular solution leads to randomly failing tests across the project. It appeared to happen due to default rxjs schedulers corruption.

Fix the issue by:
- restoring the patched function back
- using single entry point for schedulers patching