### PR TITLE
More accurate subscriber for observe helper is added

### DIFF
--- a/examples/jasmine/observe-spec.ts
+++ b/examples/jasmine/observe-spec.ts
@@ -1,6 +1,6 @@
 import { observe } from "rxjs-marbles/jasmine";
 import { of } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { finalize, map, tap } from "rxjs/operators";
 
 describe("observe", () => {
   it(
@@ -9,6 +9,17 @@ describe("observe", () => {
       return of(1).pipe(
         map(value => value.toString()),
         tap(value => expect(typeof value).toEqual("string"))
+      );
+    })
+  );
+
+  it(
+    "should handle assertions in finalize operator",
+    observe(() => {
+      const mock = jasmine.createSpy();
+      return of(1).pipe(
+        tap(() => mock()),
+        finalize(() => expect(mock).toHaveBeenCalled())
       );
     })
   );

--- a/examples/jest/observe-spec.ts
+++ b/examples/jest/observe-spec.ts
@@ -1,6 +1,6 @@
 import { observe } from "rxjs-marbles/jest";
 import { of } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { finalize, map, tap } from "rxjs/operators";
 
 describe("observe", () => {
   it(
@@ -9,6 +9,17 @@ describe("observe", () => {
       return of(1).pipe(
         map(value => value.toString()),
         tap(value => expect(typeof value).toEqual("string"))
+      );
+    })
+  );
+
+  it(
+    "should handle assertions in finalize operator",
+    observe(() => {
+      const mock = jest.fn();
+      return of(1).pipe(
+        tap(() => mock()),
+        finalize(() => expect(mock).toHaveBeenCalled())
       );
     })
   );

--- a/examples/mocha/observe-spec.ts
+++ b/examples/mocha/observe-spec.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { observe } from "rxjs-marbles/mocha";
 import { of } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { finalize, map, tap } from "rxjs/operators";
 
 describe("observe", () => {
   it(
@@ -10,6 +10,18 @@ describe("observe", () => {
       return of(1).pipe(
         map(value => value.toString()),
         tap(value => expect(value).to.be.a("string"))
+      );
+    })
+  );
+
+  it(
+    "should handle assertions in finalize operator",
+    observe(() => {
+      let haveBeenCalled = false;
+      const mock = () => (haveBeenCalled = true);
+      return of(1).pipe(
+        tap(() => mock()),
+        finalize(() => assert.isOk(haveBeenCalled))
       );
     })
   );

--- a/fixtures/jasmine/failing-spec.ts
+++ b/fixtures/jasmine/failing-spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { of } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { finalize, map, tap } from "rxjs/operators";
 import { marbles, observe } from "../../dist/jasmine";
 
 if (process.env.FAILING !== "0") {
@@ -37,6 +37,17 @@ if (process.env.FAILING !== "0") {
       observe(() =>
         of("fail").pipe(tap(value => expect(value).not.toEqual("fail")))
       )
+    );
+
+    it(
+      "should fail on assertions in finalize operator",
+      observe(() => {
+        const mock = jasmine.createSpy();
+        return of("fail").pipe(
+          tap(() => mock()),
+          finalize(() => expect(mock).not.toHaveBeenCalled())
+        );
+      })
     );
   });
 }

--- a/fixtures/jasmine/passing-spec.ts
+++ b/fixtures/jasmine/passing-spec.ts
@@ -5,7 +5,7 @@
 /*tslint:disable:object-literal-sort-keys*/
 
 import { asapScheduler, of, timer } from "rxjs";
-import { delay, map, tap } from "rxjs/operators";
+import { delay, finalize, map, tap } from "rxjs/operators";
 import {
   cases,
   DoneFunction,
@@ -127,6 +127,17 @@ describe("observe", () => {
   it(
     "should support observe",
     observe(() => of("pass").pipe(tap(value => expect(value).toEqual("pass"))))
+  );
+
+  it(
+    "should handle assertions in finalize operator",
+    observe(() => {
+      const mock = jasmine.createSpy();
+      return of("pass").pipe(
+        tap(() => mock()),
+        finalize(() => expect(mock).toHaveBeenCalled())
+      );
+    })
   );
 });
 

--- a/fixtures/jest/failing-spec.ts
+++ b/fixtures/jest/failing-spec.ts
@@ -4,37 +4,53 @@
  */
 
 import { of } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { finalize, map, tap } from "rxjs/operators";
 import { marbles, observe } from "../../dist/jest";
 
 if (process.env.FAILING !== "0") {
-  test(
-    "it should fail with marbles",
-    marbles(m => {
-      const values = {
-        a: 1,
-        b: 2,
-        c: 3,
-        d: 4
-      };
+  describe("marbles", () => {
+    test(
+      "it should fail",
+      marbles(m => {
+        const values = {
+          a: 1,
+          b: 2,
+          c: 3,
+          d: 4
+        };
 
-      const source = m.hot("  --^-a-b-c-|", values);
-      const subs = "            ^-------!";
-      const expected = m.cold(" --a-a-a-|", values);
+        const source = m.hot("  --^-a-b-c-|", values);
+        const subs = "            ^-------!";
+        const expected = m.cold(" --a-a-a-|", values);
 
-      const destination = source.pipe(map(value => value + 1));
+        const destination = source.pipe(map(value => value + 1));
 
-      m.expect(destination).toBeObservable(expected);
-      m.expect(source).toHaveSubscriptions(subs);
-    })
-  );
+        m.expect(destination).toBeObservable(expected);
+        m.expect(source).toHaveSubscriptions(subs);
+      })
+    );
+  });
 
-  test(
-    "it should fail with observe",
-    observe(() =>
-      of("fail").pipe(tap(value => expect(value).not.toEqual("fail")))
-    )
-  );
+  describe("observe", () => {
+    test(
+      "it should fail",
+      observe(() =>
+        of("fail").pipe(tap(value => expect(value).not.toEqual("fail")))
+      )
+    );
+
+    test(
+      "it should fail on assertions in finalize operator",
+      observe(() => {
+        expect.assertions(1);
+        const mock = jest.fn();
+        return of("fail").pipe(
+          tap(() => mock()),
+          finalize(() => expect(mock).not.toHaveBeenCalled())
+        );
+      })
+    );
+  });
 } else {
   test("it should pass", () => {});
 }

--- a/fixtures/jest/passing-spec.ts
+++ b/fixtures/jest/passing-spec.ts
@@ -5,7 +5,7 @@
 /*tslint:disable:object-literal-sort-keys*/
 
 import { asapScheduler, of, timer } from "rxjs";
-import { delay, map, tap } from "rxjs/operators";
+import { delay, finalize, map, tap } from "rxjs/operators";
 import {
   cases,
   DoneFunction,
@@ -123,6 +123,18 @@ describe("observe", () => {
   test(
     "it should support observe",
     observe(() => of("pass").pipe(tap(value => expect(value).toEqual("pass"))))
+  );
+
+  test(
+    "it should handle assertions in finalize operator",
+    observe(() => {
+      expect.assertions(1);
+      const mock = jest.fn();
+      return of("pass").pipe(
+        tap(() => mock()),
+        finalize(() => expect(mock).toHaveBeenCalled())
+      );
+    })
   );
 });
 

--- a/fixtures/mocha/failing-spec.ts
+++ b/fixtures/mocha/failing-spec.ts
@@ -3,9 +3,9 @@
  * can be found in the LICENSE file at https://github.com/cartant/rxjs-marbles
  */
 
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { of } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { finalize, map, tap } from "rxjs/operators";
 import { marbles, observe } from "../../dist/mocha";
 
 if (process.env.FAILING !== "0") {
@@ -38,6 +38,18 @@ if (process.env.FAILING !== "0") {
       observe(() =>
         of("fail").pipe(tap(value => expect(value).to.not.equal("fail")))
       )
+    );
+
+    it(
+      "should fail on assertions in finalize operator",
+      observe(() => {
+        let haveBeenCalled = false;
+        const mock = () => (haveBeenCalled = true);
+        return of("fail").pipe(
+          tap(() => mock()),
+          finalize(() => assert.isNotOk(haveBeenCalled))
+        );
+      })
     );
   });
 }

--- a/fixtures/mocha/passing-spec.ts
+++ b/fixtures/mocha/passing-spec.ts
@@ -4,9 +4,9 @@
  */
 /*tslint:disable:no-unused-expression object-literal-sort-keys*/
 
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { asapScheduler, of, timer } from "rxjs";
-import { delay, map, tap } from "rxjs/operators";
+import { delay, finalize, map, tap } from "rxjs/operators";
 import * as sinon from "sinon";
 import {
   configure,
@@ -646,6 +646,18 @@ describe("observe", () => {
   it(
     "should support observe",
     observe(() => of("pass").pipe(tap(value => expect(value).to.equal("pass"))))
+  );
+
+  it(
+    "should handle assertions in finalize operator",
+    observe(() => {
+      let haveBeenCalled = false;
+      const mock = () => (haveBeenCalled = true);
+      return of("pass").pipe(
+        tap(() => mock()),
+        finalize(() => assert.isOk(haveBeenCalled))
+      );
+    })
   );
 });
 

--- a/source/jasmine/observe.ts
+++ b/source/jasmine/observe.ts
@@ -4,6 +4,7 @@
  */
 
 import { Observable } from "rxjs";
+import { VerboseSubscriber } from "../verbose-subscriber";
 
 export interface DoneFunction {
   (): void;
@@ -13,6 +14,8 @@ export interface DoneFunction {
 export function observe<T>(
   observableTest: () => Observable<T>
 ): (done: DoneFunction) => void {
-  return (done: DoneFunction) =>
-    observableTest().subscribe(undefined, done.fail, done);
+  return (done: DoneFunction) => {
+    const subscriber = new VerboseSubscriber(done.fail, done);
+    observableTest().subscribe(subscriber);
+  };
 }

--- a/source/jest/observe.ts
+++ b/source/jest/observe.ts
@@ -4,6 +4,7 @@
  */
 
 import { Observable } from "rxjs";
+import { VerboseSubscriber } from "../verbose-subscriber";
 
 export interface DoneFunction {
   (): void;
@@ -13,6 +14,8 @@ export interface DoneFunction {
 export function observe<T>(
   observableTest: () => Observable<T>
 ): (done: DoneFunction) => void {
-  return (done: DoneFunction) =>
-    observableTest().subscribe(undefined, done.fail, done);
+  return (done: DoneFunction) => {
+    const subscriber = new VerboseSubscriber(done.fail, done);
+    observableTest().subscribe(subscriber);
+  };
 }

--- a/source/mocha/observe.ts
+++ b/source/mocha/observe.ts
@@ -4,12 +4,15 @@
  */
 
 import { Observable } from "rxjs";
+import { VerboseSubscriber } from "../verbose-subscriber";
 
 export type DoneFunction = (error?: Error) => void;
 
 export function observe<T>(
   observableTest: () => Observable<T>
 ): (done: DoneFunction) => void {
-  return (done: DoneFunction) =>
-    observableTest().subscribe(undefined, done, done);
+  return (done: DoneFunction) => {
+    const subscriber = new VerboseSubscriber(done, done);
+    observableTest().subscribe(subscriber);
+  };
 }

--- a/source/verbose-subscriber.ts
+++ b/source/verbose-subscriber.ts
@@ -1,0 +1,15 @@
+import { Subscriber } from "rxjs";
+
+export class VerboseSubscriber<T> extends Subscriber<T> {
+  constructor(private onError: (error: any) => void, onComplete: () => void) {
+    super(undefined, onError, onComplete);
+  }
+
+  unsubscribe(): void {
+    try {
+      super.unsubscribe();
+    } catch (error) {
+      this.onError(error);
+    }
+  }
+}


### PR DESCRIPTION
It prevents appearance of successful test with fails in finalize operator. When you try add some assertions in finalize operator, fails on this assertions lead to succeful tests with big warning in console. For example, it looks like this in Jest.
Test: 
```js
test(
  "it should fail on assertions in finalize operator",
  observe(() => {
    expect.assertions(1);
    const mock = jest.fn();
    return of("fail").pipe(
      tap(() => mock()),
      finalize(() => expect(mock).not.toHaveBeenCalled())
    );
  })
);
```
Output:
```shell
    ✓ it should fail on assertions in finalize operator (10ms)

console.warn node_modules/rxjs/internal/Observable.js:55
    Error {
      message: '1 errors occurred during unsubscription:\n' +
        '1) Error: \u001b[2mexpect(\u001b[22m\u001b[31mjest.fn()\u001b[39m\u001b[2m).\u001b[22mnot\u001b[2m.\u001b[22mtoHaveBeenCalled\u001b[2m()\u001b[22m\n' +
        '\n' +
        'Expected number of calls: \u001b[32m0\u001b[39m\n' +
        'Received number of calls: \u001b[31m1\u001b[39m\n' +
        '\n' +
        '1: called with 0 arguments',
      name: 'UnsubscriptionError',
      errors: [
        JestAssertionError: expect(jest.fn()).not.toHaveBeenCalled()
        
        Expected number of calls: 0
        Received number of calls: 1
        
        1: called with 0 arguments
            at Subscription._unsubscribe {
          matcherResult: [Object]
        }
      ]
    }
``` 

After changes made in this PR, this code leads to obvious test failure. It is linked with [this code](https://github.com/ReactiveX/rxjs/blob/master/src/internal/Observable.ts#L247) in RxJS. The reason of this behaviour is that stream already closed when we throw error.